### PR TITLE
Differentiate between development requirements and installation requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ target/
 
 # Vim swap files
 *.swp
+
+# development virtualenv
+devenv/

--- a/README.md
+++ b/README.md
@@ -1,15 +1,23 @@
-# tdl-client-python
-tdl-client-python
+# tdl-client-python Development
 
+Setting up a development environment:
+```
+pip install tox
+cd tdl-client-python
+tox -e devenv
+```
+Your virtualenv will be created in `./devenv/`
 
-pip install -r requirements.txt
+Running all the tests,
+```
+tox
+```
 
+Pass arguments to behave, e.g. to run a specific scenario,
+```
+tox -- -n \'Trial run does not count\'
+```
 
 # How to use Python virtualenvs
 
 Link: http://www.marinamele.com/2014/05/install-python-virtualenv-virtualenvwrapper-mavericks.html
-
-lsvirtualenv
-workon myenvironment
-
-deactivate

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Your virtualenv will be created in `./devenv/`
 
 Running all the tests,
 ```
+git submodule update --init
+./broker/activemq-wrapper start
 tox
 ```
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ Setting up a development environment:
 ```
 pip install tox
 cd tdl-client-python
+git submodule update --init
+./broker/activemq-wrapper start
 tox -e devenv
 ```
 Your virtualenv will be created in `./devenv/`
 
 Running all the tests,
 ```
-git submodule update --init
-./broker/activemq-wrapper start
 tox
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests==2.7.0
 behave==1.2.5
-stomp.py==4.1.5
 PyHamcrest==1.8.5

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ setup(
     name = 'tdl-client-python',
     packages = ['tdl'],
     package_dir = {'': 'src'},
+    install_requires = ['stomp.py==4.1.5'],
     version = VERSION,
     description = 'tdl-client-python',
     author = 'Tim Preece, Julian Ghionoiu',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py27
+
+[testenv]
+deps = -rrequirements.txt
+commands = behave
+
+[testenv:devenv]
+envdir = devenv
+basepython = python2.7
+usedevelop = True
+deps = -rrequirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py27
 
 [testenv]
 deps = -rrequirements.txt
-commands = behave
+commands = behave {posargs}
 
 [testenv:devenv]
 envdir = devenv


### PR DESCRIPTION
The stomp library is required by the tdl client so I have moved this into the setup.py file.  It will now be installed automatically when tdl-client-python is installed using pip.
I have also configured the project to use tox (see notes to README.md).  tox is useful because:
- it creates your development virtualenv for you (including requirements in the requirements.txt file and setup.py file)
- if/when we decide to start supporting Python3 we can configure tox to run tests in both Python2.x and Python3.x.
  I found that if I cloned the repo, ran the steps to set up the development environment on the README.md, then opened the project in PyCharm, PyCharm would automatically select the correct devenv virtualenv.
